### PR TITLE
bugfix: stringified xhr data

### DIFF
--- a/misc/tracing/tracing-server.js
+++ b/misc/tracing/tracing-server.js
@@ -101,7 +101,7 @@ const filter = (requestBody) => {
   } else {
     for (const [k, v] of Object.entries(requestBody)) {
       if (keys.has(k)) {
-        stackData[k] = v;
+        stackData[k] = JSON.parse(v);
       }
     }
   }


### PR DESCRIPTION
## Overview

**Issue Type**

- [X] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
parsed the stringified xhr data properties




**Previous behavior**
The requestPayload and responseData properties of the xhr Data were JSON encoded

**Expected behavior**
The requestPayload and responseData properties should be native javascript arrays containing objects. 

**Screenshots & Videos**
before:
![Screenshot 2023-07-11 at 7 42 46 PM](https://github.com/oslabs-beta/vizStacks/assets/117868278/5727fc37-ec06-4260-bd77-72b4a38d8726)

after:
![Screenshot 2023-07-11 at 7 46 04 PM](https://github.com/oslabs-beta/vizStacks/assets/117868278/03c2bac3-3487-4dc4-acf0-ffacead56632)**Additional context**

