### PR TITLE
Performance Improvements: OT Instrumentation

### DIFF
--- a/misc/tracing/tracing-server.js
+++ b/misc/tracing/tracing-server.js
@@ -1,12 +1,16 @@
-const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
 const { PgInstrumentation } = require('@opentelemetry/instrumentation-pg');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 
-//Open Telemetry Auto Instrumentation
-const sdk = new NodeSDK({
-	serviceName: 'my-app',
-	traceExporter: new OTLPTraceExporter({ url: 'http://localhost:12720/v1/traces' }),
-	instrumentations: [new HttpInstrumentation(), new PgInstrumentation()],
+registerInstrumentations({
+	instrumentations: [new HttpInstrumentation(), new PgInstrumentation()]
 });
-sdk.start();
+
+const provider = new NodeTracerProvider();
+const exporter = new OTLPTraceExporter({url: 'http://localhost:12720/v1/traces'});
+provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+
+provider.register();

--- a/misc/tracing/tracing-server.ts
+++ b/misc/tracing/tracing-server.ts
@@ -1,12 +1,16 @@
-import { NodeSDK } from '@opentelemetry/sdk-node';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 
-//Open Telemetry Auto Instrumentation
-const sdk = new NodeSDK({
-	serviceName: 'my-app',
-	traceExporter: new OTLPTraceExporter({ url: 'http://localhost:12720/v1/traces' }),
-	instrumentations: [new HttpInstrumentation(), new PgInstrumentation()],
+registerInstrumentations({
+	instrumentations: [new HttpInstrumentation(), new PgInstrumentation()]
 });
-sdk.start();
+
+const provider = new NodeTracerProvider();
+const exporter = new OTLPTraceExporter({url: 'http://localhost:12720/v1/traces'});
+provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+
+provider.register();


### PR DESCRIPTION
## Overview

Modifications were made to the OpenTelemetry Instrumentation contained within the tracing-server wrappers. Response time has been reduced from ~5 seconds to a fraction of a second. 

the user must ensure they have installed the correct versions of the open telemetry dependencies in the codebase being tested.

dependency installation:
```
npm i -D @opentelemetry/instrumentation@0.41.1 @opentelemetry/exporter-trace-otlp-http@0.41.1 @opentelemetry/instrumentation-http@0.41.1 @opentelemetry/instrumentation-pg@0.36.0 @opentelemetry/sdk-trace-node@1.15.1 @opentelemetry/sdk-trace-base@1.15.1
```

dependencies:
[https://www.npmjs.com/package/@opentelemetry/instrumentation](url)
[https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-http](url)
[https://www.npmjs.com/package/@opentelemetry/instrumentation-http](url)
[https://www.npmjs.com/package/@opentelemetry/instrumentation-pg](url)
[https://www.npmjs.com/package/@opentelemetry/sdk-trace-node](url)
[https://www.npmjs.com/package/@opentelemetry/sdk-trace-base](url)