### PR TITLE
Query Parser Bug Fixes

### DIFF
--- a/pern_src/client/src/DatabaseDiagram.tsx
+++ b/pern_src/client/src/DatabaseDiagram.tsx
@@ -8,15 +8,22 @@ interface Tables {
 }
 
 interface QueryInfo {
-	[key: string]: any[];
+	[key: string]: any;
 }
 
 interface Props {
 	tables: Tables;
 	queryInfo: QueryInfo;
 }
-
 const DatabaseDiagram = ({ tables, queryInfo }: Props) => {
+	
+	//if a delete statement is used, populate the columns array with all columns
+	if (queryInfo.statementType === 'Delete'){
+		const table = Object.keys(queryInfo.columns)[0];
+		for (let i = 0; i < tables[table].length; i++){
+			queryInfo.columns[table].push(tables[table][i])
+		}
+	}
 	const nodeTypes = useMemo(() => ({ opaqueNode: NodeStyles.OpaqueNode, tableNode: NodeStyles.TableNode, legendNode: NodeStyles.LegendNode }), []);
 	const defaultViewport = { x: 0, y: 0, zoom: 1 };
 

--- a/pern_src/server/services/queryParserService.ts
+++ b/pern_src/server/services/queryParserService.ts
@@ -1,5 +1,6 @@
 //@ts-ignore
 import { parse } from 'pgsql-parser';
+const statementController = require('./queryParserStatementFunctions')
 
 function queryParser(query : string){
   if (query.includes('*') === true) return 'Sorry, statements cannot contain "*" '
@@ -7,81 +8,55 @@ function queryParser(query : string){
   const stmt = parsedQuery[0].RawStmt.stmt;
 
   //Determine which type of CRUD statement is used
-  const stmtType = Object.keys(stmt)[0];
+  const stmtType : string = Object.keys(stmt)[0];
 
   //initialize an query object to store info
   interface QueryInfo {
       [key: string]: any;
     }
+    
+  //initialize an query object to store columns info
+  interface Columns {
+    [key: string]: Array<string>;
+  }
+  const columns : Columns = {};
 
-  const queryInfo : QueryInfo = {SQL_Query : query};
+  let queryInfo : QueryInfo = {
+    SQL_Query : query,
+    statementType : stmtType.split('Stmt')[0],
+    columns : columns
+  };
 
-  switch (stmtType){
-    case 'SelectStmt': //Query uses Select
-
-      queryInfo.statementType = 'Select'
-
-      //initialize an query object to store columns info
-    interface Columns {
-      [key: string]: Array<any>;
+  //object to hold aliases
+  const aliasObj : any = {};
+  
+  switch(stmtType){
+    case 'SelectStmt':
+      statementController.populateSelectCols(stmt[stmtType], queryInfo, aliasObj);
+      break;
+      case 'InsertStmt':
+      statementController.populateInsertCols(stmt[stmtType], queryInfo, aliasObj);
+      break;
+      case 'UpdateStmt':
+      statementController.populateUpdateCols(stmt[stmtType], queryInfo, aliasObj);
+      break;
+      case 'DeleteStmt':
+        statementController.populateDeleteCols(stmt[stmtType], queryInfo, aliasObj);
+      break;
+      default:
+      console.log('Query not recognized')
+      break;
+  }
+  
+  //Alias Reassignment
+  if (Object.keys(aliasObj).length){
+    for (let table in queryInfo.columns){
+      if (aliasObj[table]){
+        queryInfo.columns[aliasObj[table]] = queryInfo.columns[table];
+        delete queryInfo.columns[table]
+      }
     }
-      var columns : Columns = {};
-      var colsArr = stmt.SelectStmt.targetList;
-
-      //if a join expression is used, the following code applies
-      if (stmt.SelectStmt.fromClause[0].JoinExpr){
-        for (let i = 0; i < colsArr.length; i++){
-          const pair = colsArr[i].ResTarget.val.ColumnRef.fields
-          if (!columns[pair[0].String.str]){
-            columns[pair[0].String.str] = [pair[1].String.str];
-          } else{
-            columns[pair[0].String.str].push(pair[1].String.str);
-          }
-        }
-      } 
-
-      //if no join expression is used, the following code applies
-      else{
-        var table = stmt.SelectStmt.fromClause[0].RangeVar.relname;
-        columns[table] = [];
-        for (let i = 0; i < colsArr.length; i++){
-          const pair = colsArr[i].ResTarget.val.ColumnRef.fields
-            columns[table].push(pair[0].String.str);
-        }
-      }
-      queryInfo.columns = columns;
-      break;
-
-    case 'InsertStmt' :
-      queryInfo.statementType = 'Insert'; //Query uses Insert
-      columns = {};
-      table = stmt.InsertStmt.relation.relname;
-      columns[table] = [];
-      colsArr = stmt.InsertStmt.cols;
-      for (let i = 0; i < colsArr.length; i++){
-        columns[table].push(colsArr[i].ResTarget.name)
-      }
-      queryInfo.columns = columns;
-
-      break;
-    case 'UpdateStmt' :
-      queryInfo.statementType = 'Update';
-      columns = {};
-      table = stmt.UpdateStmt.relation.relname;
-      columns[table] = [];
-      colsArr = stmt.UpdateStmt.targetList;
-      for (let i = 0; i < colsArr.length; i++){
-        columns[table].push(colsArr[i].ResTarget.name)
-      }
-      queryInfo.columns = columns;
-
-      break;
-    case 'DeleteStmt' :
-      queryInfo.statementType = 'Delete';
-      break;
-    default:
-      console.log("query not recognized")
-    }
+  }
     return queryInfo;
 }
 

--- a/pern_src/server/services/queryParserStatementFunctions.ts
+++ b/pern_src/server/services/queryParserStatementFunctions.ts
@@ -1,0 +1,96 @@
+interface StatementController {
+  [key: string]: any;
+}
+
+const statementController : StatementController = {};
+
+statementController.populateSelectCols = (stmt : any, queryInfo : any, aliasObj : any) : any => {
+  const columns = queryInfo.columns
+  const colsArr : Array<any> = stmt.targetList;
+  //if a left or right join statement is used
+  if (stmt.fromClause[0].JoinExpr){
+    if (stmt.fromClause[0].JoinExpr.jointype === 'JOIN_LEFT' || stmt.fromClause[0].JoinExpr.jointype === 'JOIN_RIGHT'){
+      //check to see if alias needs to be populated
+      if (stmt.fromClause[0].JoinExpr.larg.RangeVar.alias){
+        aliasObj[stmt.fromClause[0].JoinExpr.larg.RangeVar.alias.aliasname] = stmt.fromClause[0].JoinExpr.larg.RangeVar.relname;
+        aliasObj[stmt.fromClause[0].JoinExpr.rarg.RangeVar.alias.aliasname] = stmt.fromClause[0].JoinExpr.rarg.RangeVar.relname;
+        }
+  
+      //populate the columns
+      for (let i = 0; i < colsArr.length; i++){
+          const pair = colsArr[i].ResTarget.val.ColumnRef.fields;
+          if (!columns[pair[0].String.str]){
+            columns[pair[0].String.str] = [pair[1].String.str];
+          } else{
+            columns[pair[0].String.str].push(pair[1].String.str);
+          }
+        }
+    }
+    //inner join in used
+    else if (stmt.fromClause[0].JoinExpr.jointype === 'JOIN_INNER'){
+      //check to see if alias needs to be populated
+      if (stmt.fromClause[0].JoinExpr.larg.RangeVar.alias){
+        aliasObj[stmt.fromClause[0].JoinExpr.larg.RangeVar.alias.aliasname] = stmt.fromClause[0].JoinExpr.larg.RangeVar.relname;
+        aliasObj[stmt.fromClause[0].JoinExpr.rarg.RangeVar.alias.aliasname] = stmt.fromClause[0].JoinExpr.rarg.RangeVar.relname;
+        }
+      //populate the columns
+      columns[stmt.fromClause[0].JoinExpr.larg.RangeVar.relname] = [];
+      for (let i = 0; i < colsArr.length; i++){
+        // columns[stmt.fromClause[0].RangeVar.relname].push(colsArr[i].ResTarget.name)
+        columns[stmt.fromClause[0].JoinExpr.larg.RangeVar.relname].push(colsArr[i].ResTarget.val.ColumnRef.fields[0].String.str)
+      } 
+    }
+  }
+  //join statement not used
+  else{
+
+    //check to see if alias needs to be populated
+    if (stmt.fromClause[0].RangeVar.alias){
+      aliasObj[stmt.fromClause[0].RangeVar.alias.aliasname] = stmt.fromClause[0].RangeVar.relname;
+      }
+
+    //populate the columns
+    columns[stmt.fromClause[0].RangeVar.relname] = [];
+    for (let i = 0; i < colsArr.length; i++){
+      // columns[stmt.fromClause[0].RangeVar.relname].push(colsArr[i].ResTarget.name)
+      columns[stmt.fromClause[0].RangeVar.relname].push(colsArr[i].ResTarget.val.ColumnRef.fields[0].String.str)
+    }
+  }
+}
+
+statementController.populateInsertCols = (stmt : any, queryInfo : any, aliasObj : any) : any =>{
+  const columns = queryInfo.columns
+  const colsArr : Array<any> = stmt.cols;
+  const table = stmt.relation.relname;
+  columns[table] = [];
+  for (let i = 0; i < colsArr.length; i++){
+    columns[table].push(colsArr[i].ResTarget.name)
+  }
+}
+
+statementController.populateUpdateCols = (stmt : any, queryInfo : any, aliasObj : any) : any =>{
+  const columns = queryInfo.columns
+  const colsArr : Array<any> = stmt.targetList;
+
+  //check if FROM clause is used
+  if (stmt.fromClause){
+      //check to see if alias needs to be populated
+    if (stmt.fromClause[0].RangeVar.alias){
+      aliasObj[stmt.fromClause[0].RangeVar.alias.aliasname] = stmt.fromClause[0].RangeVar.relname;
+    }
+  }
+
+    //populate the columns
+    const table = stmt.relation.relname;
+    columns[table] = [];
+    for (let i = 0; i < colsArr.length; i++){
+      columns[table].push(colsArr[i].ResTarget.name)
+    }
+}
+
+statementController.populateDeleteCols = (stmt : any, queryInfo : any, aliasObj : any) : any =>{
+  const columns = queryInfo.columns
+  columns[stmt.relation.relname] = [];
+}
+
+module.exports = statementController;


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
The query parser was unable to handle aliases. That functionality has been fixed.

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**
On invest with friends, note that for getting the friends list, the table is opaque and doesn't highlight required columns.
Now those columns are being highlighted.

**Previous behavior**
Aliases were not being considered in the SQL query

**Expected behavior**
Aliases should be considered in the SQL query

**Additional context**
The query parser was completely re-written. The code is now more modularized after looking at it a second time.
The code should now be able to handle queries that would have caused issues in the first implementation.
